### PR TITLE
Support seqdiag, actdiag, nwdiag.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Blockdiag MediaWiki Extension
 requirement
 ===========
 
-- blockdiag_
+- blockdiag_ (or seqdiag, actdiag, nwdiag)
 - mediawiki >1.16
 
 .. _blockdiag: http://tk0miya.bitbucket.org/blockdiag/build/html/
@@ -33,6 +33,16 @@ example
         }
         </blockdiag>
 
+If you want to use other *diag tools, specify a name before "{", like "seqdiag {".
+
+::
+
+       <blockdiag>
+       seqdiag {
+               A -> B;
+                    B -> C;
+       }
+       </blockdiag>
 
 known issues
 ============

--- a/blockdiag.php
+++ b/blockdiag.php
@@ -7,7 +7,7 @@
 
 /**
   blockdiag_example:
-  {
+  blockdiag {
     A -> B -> C
          B -> D    
   }
@@ -54,7 +54,14 @@ if( defined( 'MEDIAWIKI' ) ) {
  * Blockdiag
  **/
 class Blockdiag {
-	private $_blockdiag_path = '/usr/bin/blockdiag';
+        private $_path_array = array(
+           'blockdiag' => '/usr/local/bin/blockdiag',
+           'seqdiag' => '/usr/local/bin/seqdiag',
+           'actdiag' => '/usr/local/bin/actdiag',
+           'nwdiag' => '/usr/local/bin/nwdiag',
+           'rackdiag' => '/usr/local/bin/rackdiag',     # in nwdiag
+           'packetdiag' => '/usr/local/bin/packetdiag', # in nwdiag
+           );
 	private $_imgType = 'png';
 	private $_hash;
 	private $_source;
@@ -64,11 +71,6 @@ class Blockdiag {
 
 	public function __construct( $blockdiagDir, $blockdiagUrl, $tmpDir, $source )
 	{
-        	if(!is_file($this->_blockdiag_path))
-        	{
-        	    throw new Exception('blockdiag is not found at the specified place ($_blockdiag_path).', 1);
-        	    return false;
-		}
 		$this->_blockdiagDir  = $blockdiagDir;
 		$this->_blockdiagUrl  = $blockdiagUrl;
 		$this->_tmpDir        = $tmpDir;
@@ -87,6 +89,19 @@ class Blockdiag {
 	}
 
 	private function _generate() {
+                if (preg_match('/^\s*(\w+)\s*{/', $this->_source, $matches)) {
+                   $diagram_type = $matches[1];
+                } else { 
+                   #return $this->_error("diagtype is not specified.");
+                   $diagram_type = 'blockdiag'; # blockdiag for default
+                }
+                
+                $diagprog_path = $this->_path_array[$diagram_type];
+        	if (!is_file($diagprog_path))
+        	{
+        	    return $this->_error("$diagram_type is not found at the specified place.");
+		}
+
 		// temporary directory check
 		if( !file_exists( $this->_tmpDir ) ){
 			if( !wfMkdirParents( $this->_tmpDir ) ) {
@@ -108,7 +123,7 @@ class Blockdiag {
 		fclose($fp);
 		
 		// generate blockdiag image
-		$cmd = $this->_blockdiag_path . ' -T ' .
+		$cmd = $diagprog_path . ' -T ' .
 			escapeshellarg( $this->_imgType ) . ' -o ' .
 			escapeshellarg( $dstTmpName ) . ' ' .
 			escapeshellarg( $srcTmpName );


### PR DESCRIPTION
Added support for seqdiag, actdiag, nwdiag to your blockdiag-mediawiki-extension.
If you specify *diag name before first "{", the one is used (like "seqdiag { A -> B }".
